### PR TITLE
Upgrade ember-cli-htmlbars to remove deprecation

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "ember-cli": "2.4.2",
     "ember-cli-app-version": "1.0.0",
     "ember-cli-dependency-checker": "1.2.0",
-    "ember-cli-htmlbars-inline-precompile": "0.3.1",
+    "ember-cli-htmlbars-inline-precompile": "^0.3.3",
     "ember-cli-inject-live-reload": "1.3.1",
     "ember-cli-qunit": "1.2.1",
     "ember-cli-release": "0.2.8",
@@ -43,7 +43,7 @@
   ],
   "dependencies": {
     "ember-cli-babel": "5.1.5",
-    "ember-cli-htmlbars": "1.0.1"
+    "ember-cli-htmlbars": "^1.0.10"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
This bumps ember-cli-htmlbars to the recommended values used in a new ember-cli-project.